### PR TITLE
Design - Only fetch anime from AniList, not manga

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,7 +8,7 @@
         const animeId = document.querySelector("#anime__id").value.match(/\d+/)[0];
         fetchQuery(graphql`
             query($id: Int) {
-                Media(idMal: $id, sort: ID) {
+                Media(idMal: $id, type: ANIME) {
                     description
                     coverImage {
                         extraLarge


### PR DESCRIPTION
The AniList GraphQL query was missing a parameter to define the media type returned. Sometimes anime got information from manga entries (often NSFW). This was fixed by explicitly setting `type: ANIME` in the query.